### PR TITLE
Fix required and value attributes

### DIFF
--- a/nodes/FormTrigger/FormTrigger.node.ts
+++ b/nodes/FormTrigger/FormTrigger.node.ts
@@ -286,14 +286,14 @@ return false;
 				) as unknown as IDataObject[];
 
 				for (const field of formFields) {
+					const valAttr = typeof field.value !== 'undefined' ? ` value="${field.value}"` : '';
+					const reqAttr = field.required ? ' required' : '';
 					htmlFields += '<div class="form-group">';
 					// No label for hidden fields
 					if (field.inputType !== 'hidden') {
 						htmlFields += `<label for="${field.name}">${field.label}</label>`;
-						htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}" value"${field.value}"/>`;
-					} else {
-						htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}" ${field.required ? 'required' : ''}/>`;
 					}
+					htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}"${valAttr}${reqAttr}/>`;
 					htmlFields += '</div>';
 				}
 			}


### PR DESCRIPTION
* The `required` attribute was not getting set on input types that weren't `hidden`.
* The value attribute was malformed due to missing an `=`. Avoid setting value="undefined"