### PR TITLE
More attributes

### DIFF
--- a/nodes/FormTrigger/FormTrigger.node.ts
+++ b/nodes/FormTrigger/FormTrigger.node.ts
@@ -170,6 +170,23 @@ export class FormTrigger implements INodeType {
 									show: {
 										inputType: [
 											'hidden',
+											'text',
+											'email',
+										],
+									},
+								},
+							},
+							{
+								displayName: 'Placeholder',
+								name: 'placeholder',
+								type: 'string',
+								default: '',
+								description: 'Placeholder value to use',
+								displayOptions : {
+									show: {
+										inputType: [
+											'text',
+											'email',
 										],
 									},
 								},
@@ -180,6 +197,13 @@ export class FormTrigger implements INodeType {
 								type: 'boolean',
 								default: false,
 								description: 'Whether the field is required or not',
+							},
+							{
+								displayName: 'Read-Only',
+								name: 'readOnly',
+								type: 'boolean',
+								default: false,
+								description: 'Whether the field is read-only or not',
 							},
 						],
 					},
@@ -287,13 +311,15 @@ return false;
 
 				for (const field of formFields) {
 					const valAttr = typeof field.value !== 'undefined' ? ` value="${field.value}"` : '';
+					const placeholderAttr = typeof field.placeholder !== 'undefined' ? ` placeholder="${field.placeholder}"` : '';
 					const reqAttr = field.required ? ' required' : '';
+					const readOnlyAttr = field.readOnly ? ' readonly' : '';
 					htmlFields += '<div class="form-group">';
 					// No label for hidden fields
 					if (field.inputType !== 'hidden') {
 						htmlFields += `<label for="${field.name}">${field.label}</label>`;
 					}
-					htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}"${valAttr}${reqAttr}/>`;
+					htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}"${placeholderAttr}${valAttr}${reqAttr}${readOnlyAttr}/>`;
 					htmlFields += '</div>';
 				}
 			}

--- a/nodes/FormTrigger/FormTrigger.node.ts
+++ b/nodes/FormTrigger/FormTrigger.node.ts
@@ -286,14 +286,14 @@ return false;
 				) as unknown as IDataObject[];
 
 				for (const field of formFields) {
+					const valAttr = typeof field.value !== 'undefined' ? ` value="${field.value}"` : '';
+					const reqAttr = field.required ? ' required' : '';
 					htmlFields += '<div class="form-group">';
 					// No label for hidden fields
 					if (field.inputType !== 'hidden') {
 						htmlFields += `<label for="${field.name}">${field.label}</label>`;
-						htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}" value"${field.value}"/>`;
-					} else {
-						htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}" ${field.required ? 'required' : ''}/>`;
 					}
+					htmlFields += `<input type="${field.inputType}" class="form-control" id="${field.name}" name="${field.name}"${valAttr}${reqAttr}/>`;
 					htmlFields += '</div>';
 				}
 			}


### PR DESCRIPTION
Assumes #2 is merged.

* Supports specifying a placeholder value on `text` and `email` input types
* Adds optional `value` attribute to `text` and `email` input types
* Adds optional `readonly` attribute to all input types