### PR TITLE
Add support for single-file uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "n8n-nodes-form-trigger",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "formidable": "^1.2.1"
+      },
       "devDependencies": {
         "@types/express": "^4.17.6",
+        "@types/formidable": "^1.0.31",
         "@types/request-promise-native": "~1.0.15",
         "@typescript-eslint/parser": "^5.29.0",
         "eslint-plugin-n8n-nodes-base": "^1.5.4",
@@ -269,6 +273,15 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/formidable": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.2.5.tgz",
+      "integrity": "sha512-zu3mQJa4hDNubEMViSj937602XdDGzK7Q5pJ5QmLUbNxclbo9tZGt5jtwM352ssZ+pqo5V4H14TBvT/ALqQQcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/json-schema": {
@@ -2711,6 +2724,15 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
+      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/fragment-cache": {
@@ -7708,6 +7730,15 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/formidable": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.2.5.tgz",
+      "integrity": "sha512-zu3mQJa4hDNubEMViSj937602XdDGzK7Q5pJ5QmLUbNxclbo9tZGt5jtwM352ssZ+pqo5V4H14TBvT/ALqQQcA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -9643,6 +9674,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "formidable": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
+      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.6",
+    "@types/formidable": "^1.0.31",
     "@types/request-promise-native": "~1.0.15",
     "@typescript-eslint/parser": "^5.29.0",
     "eslint-plugin-n8n-nodes-base": "^1.5.4",
@@ -45,5 +46,8 @@
     "prettier": "^2.7.1",
     "tslint": "^6.1.2",
     "typescript": "~4.6.0"
+  },
+  "dependencies": {
+    "formidable": "^1.2.1"
   }
 }


### PR DESCRIPTION
This PR adds support for file fields in forms. See the image below, which has an ordinary Text field and another field which is a file picker:

![image](https://github.com/Joffcom/n8n-nodes-form-trigger/assets/23390438/67a3eea0-c793-4f95-bcb0-0a0973feb3ae)

This causes the following data to be output from the Form trigger. Note that it has both JSON and binary data (though the node works as well with only JSON data, as it is now, or only binary data):

![image](https://github.com/Joffcom/n8n-nodes-form-trigger/assets/23390438/79be0c03-fb67-4b76-8fec-18b087723378)

![image](https://github.com/Joffcom/n8n-nodes-form-trigger/assets/23390438/f12c8f26-55d6-4d67-94d6-51823773f0d1)

This change would expand the scope of the Form Trigger to also include "file-ingestion" workflows, such as a workflow that prompts the user for a file and then emails it it to multiple people, or also for simulation/manual triggering of workflows that need files (such as a workflow that would normally be triggered by Gmail's On Message Received with attachments).

Currently, it's not possible to receive files, even by overriding the HTML+JS of the form, so any such workflows aren't possible (I think, I haven't actually tried, but the code doesn't seem to support file parsing)

This PR closes #1